### PR TITLE
Rexgex Edits and Added Wiki Command

### DIFF
--- a/src/commands/wiki.ts
+++ b/src/commands/wiki.ts
@@ -1,0 +1,35 @@
+import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+
+const WIKI_LINK = 'https://doc.clickup.com/9013455369/d/h/8ckwug9-53/856b548acfcac7e';
+const SECTIONS: Record<string, string> = {
+    'vip': 'https://doc.clickup.com/9013455369/d/h/8ckwug9-53/856b548acfcac7e/8ckwug9-673',
+    'game-modes': 'https://doc.clickup.com/9013455369/d/h/8ckwug9-53/856b548acfcac7e/8ckwug9-533',
+    'general-how-tos': 'https://doc.clickup.com/9013455369/d/h/8ckwug9-53/856b548acfcac7e/8ckwug9-373',
+    'season-3-government': 'https://doc.clickup.com/9013455369/d/h/8ckwug9-53/856b548acfcac7e/8ckwug9-73'
+};
+
+export const data = new SlashCommandBuilder()
+    .setName('wiki')
+    .setDescription('Get the link to the official wiki.')
+    .addStringOption(option => 
+        option.setName('section')
+            .setDescription('Specify a section of the wiki to visit')
+            .setRequired(false)
+            .addChoices(
+                { name: 'VIP', value: 'vip' },
+                { name: 'Game Modes', value: 'game-modes' },
+                { name: 'General How-Tos', value: 'general-how-tos' },
+                { name: 'Season 3 Government', value: 'season-3-government' }
+            )
+    );
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+    const section = interaction.options.getString('section');
+    if (!section) {
+        await interaction.reply({ content: `📖 Here is the main wiki link: <${WIKI_LINK}>`, ephemeral: true });
+        return;
+    }
+    
+    const link = SECTIONS[section] || WIKI_LINK;
+    await interaction.reply({ content: `📖 Here is the ${section.replace(/-/g, ' ')} wiki link: <${link}>`, ephemeral: true });
+}

--- a/src/helpers/set-nickename.ts
+++ b/src/helpers/set-nickename.ts
@@ -5,41 +5,34 @@ import * as validators from "./validators";
 const rest = new REST({ version: "10" }).setToken(config.DISCORD_TOKEN);
 
 // Will only set the nickname if a valid one is not present. (unless force=true)
-export async function execute(interaction: CommandInteraction) {
-    const uid = interaction.member!.user.id;
-    // @ts-ignore
-    const first_name = interaction.options.getString('first_name');
-    // @ts-ignore
-    const mc_username = interaction.options.getString('minecraft_name');
+export async function setNickname(
+    guild_id: string, member_id: string, current_nick: string|null,
+    first_name: string, mc_name: string ) {
 
-    // Trim the first name to remove any extra whitespace, should fix any issues
-    const trimmedName = first_name?.trim();
-
-    console.log('Extracted and trimmed first_name:', JSON.stringify(trimmedName));
-    console.log('Extracted mc_username:', mc_username);
-
-    // Set the user's nickname (if needed).
-    // @ts-ignore
-    let err = await setNickname(interaction.guildId!, uid, interaction.member!.nickname, trimmedName, mc_username);
-    if (err.length > 0) {
-        return interaction.reply({
-            content: err,
-            ephemeral: true,
-        });
+    // do they have a valid discord name already and this is not a force update?
+    if (current_nick != null && validators.isValidDiscordName(current_nick)) {
+        return "";
     }
 
-    // Add the account
-    err = await addMinecraftAccount(uid, trimmedName, mc_username);
-    if (err.length > 0) {
-        return interaction.reply({
-            content: err,
-            ephemeral: true,
-        });
+    // check first name
+    if (!validators.isValidFirstName(first_name)) {
+        return 'Please double check your first name and then try again. It needs to be at least 3 characters and no more than 12 characters.';
     }
 
-    // Success!
-    return interaction.reply({
-        content: "Success! Your account has been registered.",
-        ephemeral: true,
-    });
+    // Build NickName
+    const nick = first_name + ' (' + mc_name + ')';
+
+    // Update the name
+    try {
+        await rest.patch(Routes.guildMember(guild_id, member_id), {
+            body: {
+                nick: nick,
+            }
+        })
+    } catch (err) {
+        console.log(err);
+        //return "An Error occured while attempting to update your discord name."
+    }
+
+    return "";
 }

--- a/src/helpers/set-nickename.ts
+++ b/src/helpers/set-nickename.ts
@@ -1,37 +1,45 @@
-import {REST, Routes} from "discord.js";
-import {config} from "../config";
+import { REST, Routes } from "discord.js";
+import { config } from "../config";
 import * as validators from "./validators";
 
 const rest = new REST({ version: "10" }).setToken(config.DISCORD_TOKEN);
 
-// Will only set the nickname if a valid one is not present. (unless force=true)
 export async function setNickname(
-    guild_id: string, member_id: string, current_nick: string|null,
-    first_name: string, mc_name: string ) {
+    guild_id: string,
+    member_id: string,
+    current_nick: string | null,
+    first_name: string,
+    mc_name: string
+) {
+    // Trim the first_name to remove any extra whitespace
+    const trimmedFirstName = first_name?.trim();
 
-    // do they have a valid discord name already and this is not a force update?
+    // Log to verify the trimmed name
+    console.log('Trimmed first_name:', JSON.stringify(trimmedFirstName));
+
+    // Check if the user already has a valid Discord nickname and this is not a forced update
     if (current_nick != null && validators.isValidDiscordName(current_nick)) {
         return "";
     }
 
-    // check first name
-    if (!validators.isValidFirstName(first_name)) {
+    // Validate the trimmed first name
+    if (!validators.isValidFirstName(trimmedFirstName)) {
         return 'Please double check your first name and then try again. It needs to be at least 3 characters and no more than 12 characters.';
     }
 
     // Build NickName
-    const nick = first_name + ' (' + mc_name + ')';
+    const nick = `${trimmedFirstName} (${mc_name})`;
 
     // Update the name
     try {
         await rest.patch(Routes.guildMember(guild_id, member_id), {
             body: {
                 nick: nick,
-            }
-        })
+            },
+        });
     } catch (err) {
         console.log(err);
-        //return "An Error occured while attempting to update your discord name."
+        // Optionally return an error message if needed
     }
 
     return "";

--- a/src/helpers/set-nickename.ts
+++ b/src/helpers/set-nickename.ts
@@ -5,34 +5,41 @@ import * as validators from "./validators";
 const rest = new REST({ version: "10" }).setToken(config.DISCORD_TOKEN);
 
 // Will only set the nickname if a valid one is not present. (unless force=true)
-export async function setNickname(
-    guild_id: string, member_id: string, current_nick: string|null,
-    first_name: string, mc_name: string ) {
+export async function execute(interaction: CommandInteraction) {
+    const uid = interaction.member!.user.id;
+    // @ts-ignore
+    const first_name = interaction.options.getString('first_name');
+    // @ts-ignore
+    const mc_username = interaction.options.getString('minecraft_name');
 
-    // do they have a valid discord name already and this is not a force update?
-    if (current_nick != null && validators.isValidDiscordName(current_nick)) {
-        return "";
+    // Trim the first name to remove any extra whitespace, should fix any issues
+    const trimmedName = first_name?.trim();
+
+    console.log('Extracted and trimmed first_name:', JSON.stringify(trimmedName));
+    console.log('Extracted mc_username:', mc_username);
+
+    // Set the user's nickname (if needed).
+    // @ts-ignore
+    let err = await setNickname(interaction.guildId!, uid, interaction.member!.nickname, trimmedName, mc_username);
+    if (err.length > 0) {
+        return interaction.reply({
+            content: err,
+            ephemeral: true,
+        });
     }
 
-    // check first name
-    if (!validators.isValidFirstName(first_name)) {
-        return 'Please double check your first name and then try again. It needs to be at least 3 characters and no more than 12 characters.';
+    // Add the account
+    err = await addMinecraftAccount(uid, trimmedName, mc_username);
+    if (err.length > 0) {
+        return interaction.reply({
+            content: err,
+            ephemeral: true,
+        });
     }
 
-    // Build NickName
-    const nick = first_name + ' (' + mc_name + ')';
-
-    // Update the name
-    try {
-        await rest.patch(Routes.guildMember(guild_id, member_id), {
-            body: {
-                nick: nick,
-            }
-        })
-    } catch (err) {
-        console.log(err);
-        //return "An Error occured while attempting to update your discord name."
-    }
-
-    return "";
+    // Success!
+    return interaction.reply({
+        content: "Success! Your account has been registered.",
+        ephemeral: true,
+    });
 }

--- a/src/helpers/validators.ts
+++ b/src/helpers/validators.ts
@@ -5,19 +5,19 @@
 
 
 export const isValidMinecraftName = function(name) {
-    const regex = /[A-Za-z0-9_]{3,16}$/
+    const regex = /^[A-Za-z0-9_]{3,16}$/
     if (name == null) return false;
     return name.match(regex) != null;
 }
 
 export const isValidFirstName = function(name) {
-    const regex = /.{3,12}$/
+    const regex = /^.{3,12}$/
     if (name == null) return false;
     return name.match(regex) != null;
 }
 
 export const isValidDiscordName = function(name) {
-    const regex = /.+ \(\.?[A-Za-z0-9_]{3,16}\)$/
+    const regex = /^.+ \(\.?[A-Za-z0-9_]{3,16}\)$/
     if (name == null) return false;
     return name.match(regex) != null;
 }


### PR DESCRIPTION
Console output:

```
mazey@somc ~/somc % docker logs container
error setting nick: Please double check your first name and then try again. It needs to be at least 3 characters and no more than 12 characters.
1209539928866816143
1209539928866816143
mazey@somc ~/somc %
```



Changed regex to be more strict and also added in a anti-whitespace maker.

This fix can address the issue where `(TBD)` was appended incorrectly because the problem likely originates from how the `setNickname` function constructs the nickname.

In the `register.ts` file, the value `"TBD"` is hardcoded as the second part of the nickname when calling `setNickname` as a failsafe, but the error on the first half mean that the second half wasn't working. (If I have understood it correctly)